### PR TITLE
Convert P&L metrics from USD to percentage-based calculations

### DIFF
--- a/src/lib/components/ModuleCalendar.tsx
+++ b/src/lib/components/ModuleCalendar.tsx
@@ -1,5 +1,6 @@
 import type { TradesRow } from '@lib/database/TradesApi';
-import { toUSD } from '@lib/utils/MathUtils';
+import { toPercent } from '@lib/utils/MathUtils';
+import { getTradePnlPercent } from '@lib/utils/TradeUtils';
 import { Module, type ModuleProps } from './Module';
 
 type ModuleCalendarProps = { trades: TradesRow[]; monthDate: Date } & ModuleProps;
@@ -83,7 +84,7 @@ export function ModuleCalendar({ trades, monthDate, className, ...props }: Modul
                     className={`number${Math.sign(totalPnl)}`}
                     style={{ fontWeight: 600, fontSize: 16 }}
                   >
-                    {toUSD(totalPnl)}
+                    {toPercent(totalPnl)}
                   </span>
                   <span>
                     {totalTrades} {totalTrades === 1 ? 'trade' : 'trades'}
@@ -110,7 +111,7 @@ const calculateDailyStats = (date: Date, trades: TradesRow[]) => {
     return isSameLocalDay(t, date);
   });
   const totalPnl = dailyTrades.reduce(
-    (acc, trade) => acc + (trade.executed ? trade.pnl || 0 : 0),
+    (acc, trade) => acc + (trade.executed ? getTradePnlPercent(trade) : 0),
     0,
   );
   return { totalTrades: dailyTrades.length, totalPnl };

--- a/src/lib/components/ModuleDashboardMetrics.tsx
+++ b/src/lib/components/ModuleDashboardMetrics.tsx
@@ -1,5 +1,5 @@
 import type { TradesRow } from '@lib/database/TradesApi';
-import { getTradePnl } from '@lib/utils/TradeUtils';
+import { getTradePnl, getTradePnlPercent } from '@lib/utils/TradeUtils';
 
 type Props = { trades: TradesRow[] };
 
@@ -7,7 +7,7 @@ export function ModuleDashboardMetrics({ trades }: Props) {
   const executed = trades.filter((t) => t.executed);
   const skipped = trades.filter((t) => !t.executed);
 
-  const netPnl = executed.reduce((sum, t) => sum + (t.pnl ?? 0), 0);
+  const netPnl = executed.reduce((sum, t) => sum + getTradePnlPercent(t), 0);
 
   const wins = executed.filter((t) => (t.pnl ?? 0) > 0);
   const losses = executed.filter((t) => (t.pnl ?? 0) <= 0);
@@ -23,18 +23,21 @@ export function ModuleDashboardMetrics({ trades }: Props) {
 
   const avgWin =
     wins.length > 0
-      ? wins.reduce((sum, t) => sum + (t.pnl ?? 0), 0) / wins.length
+      ? wins.reduce((sum, t) => sum + getTradePnlPercent(t), 0) / wins.length
       : 0;
   const avgLoss =
     losses.length > 0
       ? Math.abs(
-          losses.reduce((sum, t) => sum + (t.pnl ?? 0), 0) / losses.length,
+          losses.reduce((sum, t) => sum + getTradePnlPercent(t), 0) /
+            losses.length,
         )
       : 0;
   const rrRatio = avgLoss > 0 ? avgWin / avgLoss : null;
 
-  const totalProfit = wins.reduce((sum, t) => sum + (t.pnl ?? 0), 0);
-  const totalLoss = Math.abs(losses.reduce((sum, t) => sum + (t.pnl ?? 0), 0));
+  const totalProfit = wins.reduce((sum, t) => sum + getTradePnlPercent(t), 0);
+  const totalLoss = Math.abs(
+    losses.reduce((sum, t) => sum + getTradePnlPercent(t), 0),
+  );
   const profitFactor = totalLoss > 0 ? totalProfit / totalLoss : null;
   const profitFactorColor =
     profitFactor === null
@@ -46,7 +49,8 @@ export function ModuleDashboardMetrics({ trades }: Props) {
           : 'var(--color-short)';
 
   const missedPnl = skipped.reduce(
-    (sum, t) => sum + getTradePnl({ ...t, exit: t.target }),
+    (sum, t) =>
+      sum + (t.account ? (getTradePnl({ ...t, exit: t.target }) / t.account) * 100 : 0),
     0,
   );
 
@@ -56,7 +60,7 @@ export function ModuleDashboardMetrics({ trades }: Props) {
         label="Profit factor"
         value={profitFactor !== null ? profitFactor.toFixed(2) : '—'}
         valueColor={profitFactorColor}
-        sub={`$${totalProfit.toFixed(2)} / $${totalLoss.toFixed(2)}`}
+        sub={`${totalProfit.toFixed(2)}% / ${totalLoss.toFixed(2)}%`}
       />
       <MetricCard
         label="Win rate"
@@ -69,7 +73,7 @@ export function ModuleDashboardMetrics({ trades }: Props) {
         valueColor={
           rrRatio !== null && rrRatio >= 1 ? 'var(--color-long)' : undefined
         }
-        sub={`$${avgWin.toFixed(2)} / $${avgLoss.toFixed(2)}`}
+        sub={`${avgWin.toFixed(2)}% / ${avgLoss.toFixed(2)}%`}
       />
       <MetricCard
         label="Avg risk"
@@ -78,13 +82,13 @@ export function ModuleDashboardMetrics({ trades }: Props) {
       />
       <MetricCard
         label="Net P&L"
-        value={`${netPnl >= 0 ? '+' : ''}$${netPnl.toFixed(2)}`}
+        value={`${netPnl >= 0 ? '+' : ''}${netPnl.toFixed(2)}%`}
         valueColor={netPnl >= 0 ? 'var(--color-long)' : 'var(--color-short)'}
         sub="executed trades"
       />
       <MetricCard
         label="Missed P&L"
-        value={`${missedPnl >= 0 ? '+' : ''}$${missedPnl.toFixed(2)}`}
+        value={`${missedPnl >= 0 ? '+' : ''}${missedPnl.toFixed(2)}%`}
         valueColor="orange"
         sub="skipped setups"
       />

--- a/src/lib/utils/MathUtils.ts
+++ b/src/lib/utils/MathUtils.ts
@@ -13,6 +13,10 @@ export function toUSD(value: number | null | undefined) {
   );
 }
 
+export function toPercent(value: number | null | undefined) {
+  return value != null ? `${value >= 0 ? '+' : ''}${value.toFixed(2)}%` : '';
+}
+
 export function toEUR(value: number | null | undefined) {
   return (
     value?.toLocaleString('nl-NL', {

--- a/src/lib/utils/TradeUtils.ts
+++ b/src/lib/utils/TradeUtils.ts
@@ -49,6 +49,10 @@ export function getTradeRisk(trade: TradesRow): number {
   return round(ratio * risk, 4);
 }
 
+export function getTradePnlPercent(trade: TradesRow): number {
+  return trade.account ? round(((trade.pnl ?? 0) / trade.account) * 100, 2) : 0;
+}
+
 export function getTradeLongShort({
   stop,
   entry,


### PR DESCRIPTION
## Summary
This PR converts all P&L (profit & loss) metrics throughout the dashboard and calendar views from absolute USD values to percentage-based calculations relative to account size. This provides a more normalized view of trading performance that is independent of account balance.

## Key Changes

- **New utility function**: Added `getTradePnlPercent()` in `TradeUtils.ts` to calculate P&L as a percentage of account balance
- **New formatter**: Added `toPercent()` in `MathUtils.ts` to format percentage values with consistent styling
- **Dashboard metrics**: Updated `ModuleDashboardMetrics.tsx` to use percentage-based calculations for:
  - Net P&L (executed trades)
  - Average win/loss
  - Win/loss totals and profit factor
  - Risk/reward ratio display
  - Missed P&L (skipped setups)
- **Calendar view**: Updated `ModuleCalendar.tsx` to display daily P&L as percentages instead of USD
- **Display formatting**: Changed all P&L display values from `$X.XX` format to `X.XX%` format

## Implementation Details

- `getTradePnlPercent()` safely handles missing account data by returning 0 when account is not available
- The missed P&L calculation for skipped trades now converts the absolute PnL to a percentage by dividing by account balance and multiplying by 100
- All metric cards that previously showed USD values now display percentages with appropriate sign indicators (+/-)
- The change maintains all existing metric calculations (win rate, profit factor, R:R ratio) but uses percentage-based inputs

https://claude.ai/code/session_017yPrpFsEEuhYmDLtzsrL6H