### PR TITLE
Add mock mode for development and testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://kadimara.github.io/traders-tale",
   "scripts": {
     "dev": "vite",
+    "dev:mock": "vite --mode mock",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/src/lib/context/SessionContext.tsx
+++ b/src/lib/context/SessionContext.tsx
@@ -7,6 +7,8 @@ import {
   type PropsWithChildren,
 } from 'react';
 import { supabase } from '@lib/database/SupabaseClient';
+import { isMockMode } from '@lib/mock/mockMode';
+import { MOCK_SESSION } from '@lib/mock/mockData';
 import { router } from '../../router';
 
 type SessionContextType = {
@@ -21,10 +23,14 @@ function isPublicRoute() {
 }
 
 export function SessionProvider({ children }: PropsWithChildren) {
-  const [session, setSession] = useState<Session | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [session, setSession] = useState<Session | null>(
+    isMockMode ? MOCK_SESSION : null,
+  );
+  const [loading, setLoading] = useState(!isMockMode);
 
   useEffect(() => {
+    if (isMockMode) return;
+
     // Get current session
     supabase.auth.getSession().then(({ data: { session } }) => {
       setSession(session);

--- a/src/lib/database/MonthlyPlanApi.ts
+++ b/src/lib/database/MonthlyPlanApi.ts
@@ -1,5 +1,12 @@
 import type { Database } from '@lib/types/database.types';
 import { supabase } from './SupabaseClient';
+import { isMockMode } from '@lib/mock/mockMode';
+import {
+  mockMonthlyPlans,
+  mockUpdateRow,
+  mockDeleteRow,
+  MOCK_USER_ID,
+} from '@lib/mock/mockData';
 
 export type MonthlyPlanRow =
   Database['public']['Tables']['monthly_plan']['Row'];
@@ -9,6 +16,14 @@ export type MonthlyPlanUpdate =
   Database['public']['Tables']['monthly_plan']['Update'];
 
 export async function monthlyPlanSelectByMonth(monthYear: string, userId: string) {
+  if (isMockMode) {
+    return (
+      mockMonthlyPlans.find(
+        (plan) => plan.month_year === monthYear && plan.user_id === userId,
+      ) ?? null
+    );
+  }
+
   const { data, error } = await supabase
     .from('monthly_plan')
     .select('*')
@@ -21,6 +36,24 @@ export async function monthlyPlanSelectByMonth(monthYear: string, userId: string
 }
 
 export async function monthlyPlanUpsert(plan: MonthlyPlanInsert) {
+  if (isMockMode) {
+    const existing = mockMonthlyPlans.find(
+      (row) => row.month_year === plan.month_year && row.user_id === plan.user_id,
+    );
+    if (existing) return mockUpdateRow(mockMonthlyPlans, existing.id, plan);
+
+    const newPlan: MonthlyPlanRow = {
+      content: plan.content,
+      created_at: plan.created_at ?? new Date().toISOString(),
+      id: plan.id ?? crypto.randomUUID(),
+      month_year: plan.month_year,
+      updated_at: plan.updated_at ?? new Date().toISOString(),
+      user_id: plan.user_id ?? MOCK_USER_ID,
+    };
+    mockMonthlyPlans.push(newPlan);
+    return newPlan;
+  }
+
   const { data, error } = await supabase
     .from('monthly_plan')
     .upsert([plan], {
@@ -34,6 +67,8 @@ export async function monthlyPlanUpsert(plan: MonthlyPlanInsert) {
 }
 
 export async function monthlyPlanUpdate(id: string, plan: MonthlyPlanUpdate) {
+  if (isMockMode) return mockUpdateRow(mockMonthlyPlans, id, plan);
+
   const { data, error } = await supabase
     .from('monthly_plan')
     .update(plan)
@@ -46,6 +81,8 @@ export async function monthlyPlanUpdate(id: string, plan: MonthlyPlanUpdate) {
 }
 
 export async function monthlyPlanDelete(id: string) {
+  if (isMockMode) return mockDeleteRow(mockMonthlyPlans, id);
+
   const { error } = await supabase.from('monthly_plan').delete().eq('id', id);
   if (error) throw error;
 }

--- a/src/lib/database/SpotApi.ts
+++ b/src/lib/database/SpotApi.ts
@@ -1,5 +1,13 @@
 import type { Database } from '@lib/types/database.types';
 import { supabase } from './SupabaseClient';
+import { isMockMode } from '@lib/mock/mockMode';
+import {
+  mockTradesSpot,
+  nextMockSpotId,
+  mockUpdateRow,
+  mockDeleteRow,
+  MOCK_USER_ID,
+} from '@lib/mock/mockData';
 
 export type TradesSpotRow = Database['public']['Tables']['trades_spot']['Row'];
 export type TradesSpotInsert =
@@ -8,6 +16,12 @@ export type TradesSpotUpdate =
   Database['public']['Tables']['trades_spot']['Update'];
 
 export async function tradesSpotSelectAll() {
+  if (isMockMode) {
+    return [...mockTradesSpot].sort((a, b) =>
+      b.created_at.localeCompare(a.created_at),
+    );
+  }
+
   const { data, error } = await supabase
     .from('trades_spot')
     .select('*')
@@ -18,6 +32,24 @@ export async function tradesSpotSelectAll() {
 }
 
 export async function tradesSpotInsert(trade: TradesSpotInsert) {
+  if (isMockMode) {
+    const newTrade: TradesSpotRow = {
+      amount: trade.amount,
+      created_at: trade.created_at ?? new Date().toISOString(),
+      description: trade.description ?? null,
+      entry: trade.entry,
+      executed: trade.executed ?? false,
+      exit: trade.exit ?? null,
+      id: nextMockSpotId(),
+      pnl: trade.pnl ?? null,
+      symbol: trade.symbol,
+      url: trade.url ?? null,
+      user_id: trade.user_id ?? MOCK_USER_ID,
+    };
+    mockTradesSpot.unshift(newTrade);
+    return newTrade;
+  }
+
   const { data, error } = await supabase
     .from('trades_spot')
     .insert([trade])
@@ -30,6 +62,8 @@ export async function tradesSpotInsert(trade: TradesSpotInsert) {
 }
 
 export async function tradesSpotUpdate(id: number, trade: TradesSpotUpdate) {
+  if (isMockMode) return mockUpdateRow(mockTradesSpot, id, trade);
+
   const { data, error } = await supabase
     .from('trades_spot')
     .update(trade)
@@ -42,6 +76,8 @@ export async function tradesSpotUpdate(id: number, trade: TradesSpotUpdate) {
 }
 
 export async function tradesSpotDelete(id: number) {
+  if (isMockMode) return mockDeleteRow(mockTradesSpot, id);
+
   const { error } = await supabase.from('trades_spot').delete().eq('id', id);
   if (error) throw error;
 }

--- a/src/lib/database/SupabaseClient.ts
+++ b/src/lib/database/SupabaseClient.ts
@@ -1,7 +1,10 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import type { Database } from '@lib/types/database.types';
+import { isMockMode } from '@lib/mock/mockMode';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseKey = import.meta.env.VITE_SUPABASE_KEY;
 
-export const supabase = createClient<Database>(supabaseUrl, supabaseKey);
+export const supabase: SupabaseClient<Database> = isMockMode
+  ? (null as unknown as SupabaseClient<Database>)
+  : createClient<Database>(supabaseUrl, supabaseKey);

--- a/src/lib/database/TradesApi.ts
+++ b/src/lib/database/TradesApi.ts
@@ -1,11 +1,25 @@
 import type { Database } from '@lib/types/database.types';
 import { supabase } from './SupabaseClient';
+import { isMockMode } from '@lib/mock/mockMode';
+import {
+  mockTrades,
+  nextMockTradeId,
+  mockUpdateRow,
+  mockDeleteRow,
+  MOCK_USER_ID,
+} from '@lib/mock/mockData';
 
 export type TradesRow = Database['public']['Tables']['trades']['Row'];
 export type TradesInsert = Database['public']['Tables']['trades']['Insert'];
 export type TradesUpdate = Database['public']['Tables']['trades']['Update'];
 
 export async function tradesSelectAll() {
+  if (isMockMode) {
+    return [...mockTrades].sort((a, b) =>
+      b.created_at.localeCompare(a.created_at),
+    );
+  }
+
   const { data, error } = await supabase
     .from('trades')
     .select('*')
@@ -20,6 +34,15 @@ export async function tradesSelectByMonth(monthKey: string) {
   const endDate = new Date(startDate);
   endDate.setMonth(endDate.getMonth() + 1);
 
+  if (isMockMode) {
+    return mockTrades
+      .filter((trade) => {
+        const createdAt = new Date(trade.created_at);
+        return createdAt >= startDate && createdAt < endDate;
+      })
+      .sort((a, b) => b.created_at.localeCompare(a.created_at));
+  }
+
   const { data, error } = await supabase
     .from('trades')
     .select('*')
@@ -32,6 +55,31 @@ export async function tradesSelectByMonth(monthKey: string) {
 }
 
 export async function tradesInsert(trade: TradesInsert) {
+  if (isMockMode) {
+    const newTrade: TradesRow = {
+      account: trade.account,
+      amount: trade.amount,
+      created_at: trade.created_at ?? new Date().toISOString(),
+      entry: trade.entry,
+      executed: trade.executed ?? false,
+      exit: trade.exit ?? null,
+      fees: trade.fees ?? null,
+      id: nextMockTradeId(),
+      journal: trade.journal ?? null,
+      long_short: trade.long_short,
+      playbook: trade.playbook ?? false,
+      pnl: trade.pnl ?? null,
+      risk: trade.risk ?? null,
+      stop: trade.stop,
+      symbol: trade.symbol,
+      target: trade.target,
+      time_frame: trade.time_frame,
+      user_id: trade.user_id ?? MOCK_USER_ID,
+    };
+    mockTrades.unshift(newTrade);
+    return newTrade;
+  }
+
   const { data, error } = await supabase
     .from('trades')
     .insert([trade])
@@ -44,6 +92,8 @@ export async function tradesInsert(trade: TradesInsert) {
 }
 
 export async function tradesUpdate(id: number, trade: TradesUpdate) {
+  if (isMockMode) return mockUpdateRow(mockTrades, id, trade);
+
   const { data, error } = await supabase
     .from('trades')
     .update(trade)
@@ -56,6 +106,12 @@ export async function tradesUpdate(id: number, trade: TradesUpdate) {
 }
 
 export async function tradesSelectById(id: number) {
+  if (isMockMode) {
+    const trade = mockTrades.find((t) => t.id === id);
+    if (!trade) throw new Error(`Mock trade with id ${id} not found`);
+    return trade;
+  }
+
   const { data, error } = await supabase
     .from('trades')
     .select('*')
@@ -67,11 +123,19 @@ export async function tradesSelectById(id: number) {
 }
 
 export async function tradesDelete(id: number) {
+  if (isMockMode) return mockDeleteRow(mockTrades, id);
+
   const { error } = await supabase.from('trades').delete().eq('id', id);
   if (error) throw error;
 }
 
 export async function tradesSelectPlaybook() {
+  if (isMockMode) {
+    return mockTrades
+      .filter((trade) => trade.playbook)
+      .sort((a, b) => b.created_at.localeCompare(a.created_at));
+  }
+
   const { data, error } = await supabase
     .from('trades')
     .select('*')

--- a/src/lib/mock/mockData.ts
+++ b/src/lib/mock/mockData.ts
@@ -1,0 +1,343 @@
+import type { Database } from '@lib/types/database.types';
+import type { Session } from '@supabase/supabase-js';
+
+type TradesRow = Database['public']['Tables']['trades']['Row'];
+type TradesSpotRow = Database['public']['Tables']['trades_spot']['Row'];
+type MonthlyPlanRow = Database['public']['Tables']['monthly_plan']['Row'];
+
+export const MOCK_USER_ID = '11111111-1111-4111-8111-111111111111';
+
+export const MOCK_SESSION: Session = {
+  access_token: 'mock-access-token',
+  refresh_token: 'mock-refresh-token',
+  expires_in: 3600,
+  token_type: 'bearer',
+  user: {
+    id: MOCK_USER_ID,
+    aud: 'authenticated',
+    app_metadata: {},
+    user_metadata: { display_name: 'Demo Trader' },
+    email: 'demo@traderstale.local',
+    created_at: new Date().toISOString(),
+  },
+};
+
+function daysAgo(n: number): string {
+  const d = new Date();
+  d.setHours(12, 0, 0, 0);
+  d.setDate(d.getDate() - n);
+  return d.toISOString();
+}
+
+function previousMonthOn(day: number): string {
+  const d = new Date();
+  d.setDate(1);
+  d.setMonth(d.getMonth() - 1);
+  d.setDate(day);
+  d.setHours(12, 0, 0, 0);
+  return d.toISOString();
+}
+
+function currentMonthKey(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-01`;
+}
+
+export const mockTrades: TradesRow[] = [
+  {
+    id: 1,
+    account: 1,
+    amount: 2,
+    created_at: daysAgo(1),
+    entry: 5720.25,
+    executed: true,
+    exit: 5748.5,
+    fees: 4.5,
+    journal: 'Clean breakout above VWAP, held through the pullback.',
+    long_short: 'long',
+    playbook: true,
+    pnl: 565,
+    risk: 100,
+    stop: 5695,
+    symbol: 'ES',
+    target: 5760,
+    time_frame: '15m',
+    user_id: MOCK_USER_ID,
+  },
+  {
+    id: 2,
+    account: 1,
+    amount: 1,
+    created_at: daysAgo(2),
+    entry: 20450,
+    executed: true,
+    exit: 20395,
+    fees: 2.25,
+    journal: null,
+    long_short: 'short',
+    playbook: false,
+    pnl: 275,
+    risk: 70,
+    stop: 20520,
+    symbol: 'NQ',
+    target: 20360,
+    time_frame: '5m',
+    user_id: MOCK_USER_ID,
+  },
+  {
+    id: 3,
+    account: 1,
+    amount: 3,
+    created_at: daysAgo(0),
+    entry: 78.42,
+    executed: true,
+    exit: null,
+    fees: null,
+    journal: 'Still open, watching the inventory report.',
+    long_short: 'long',
+    playbook: false,
+    pnl: null,
+    risk: 246,
+    stop: 77.6,
+    symbol: 'CL',
+    target: 80.1,
+    time_frame: '1h',
+    user_id: MOCK_USER_ID,
+  },
+  {
+    id: 4,
+    account: 2,
+    amount: 1,
+    created_at: daysAgo(4),
+    entry: 2385.4,
+    executed: true,
+    exit: 2402.1,
+    fees: 3.1,
+    journal: 'Faded resistance too early.',
+    long_short: 'short',
+    playbook: true,
+    pnl: -167,
+    risk: 245,
+    stop: 2410,
+    symbol: 'GC',
+    target: 2350,
+    time_frame: '30m',
+    user_id: MOCK_USER_ID,
+  },
+  {
+    id: 5,
+    account: 1,
+    amount: 1,
+    created_at: daysAgo(0),
+    entry: 5702,
+    executed: false,
+    exit: null,
+    fees: null,
+    journal: 'Planned setup, not triggered yet.',
+    long_short: 'long',
+    playbook: false,
+    pnl: null,
+    risk: 22,
+    stop: 5680,
+    symbol: 'ES',
+    target: 5740,
+    time_frame: '15m',
+    user_id: MOCK_USER_ID,
+  },
+  {
+    id: 6,
+    account: 1,
+    amount: 2,
+    created_at: previousMonthOn(20),
+    entry: 20180,
+    executed: true,
+    exit: 20260,
+    fees: 4.5,
+    journal: 'Textbook reversal off VWAP.',
+    long_short: 'long',
+    playbook: true,
+    pnl: 800,
+    risk: 120,
+    stop: 20120,
+    symbol: 'NQ',
+    target: 20280,
+    time_frame: '5m',
+    user_id: MOCK_USER_ID,
+  },
+  {
+    id: 7,
+    account: 2,
+    amount: 2,
+    created_at: previousMonthOn(15),
+    entry: 79.8,
+    executed: true,
+    exit: 80.35,
+    fees: 2.4,
+    journal: null,
+    long_short: 'short',
+    playbook: false,
+    pnl: -110,
+    risk: 140,
+    stop: 80.5,
+    symbol: 'CL',
+    target: 78.2,
+    time_frame: '1h',
+    user_id: MOCK_USER_ID,
+  },
+  {
+    id: 8,
+    account: 2,
+    amount: 1,
+    created_at: previousMonthOn(10),
+    entry: 2360,
+    executed: true,
+    exit: 2388,
+    fees: 1.9,
+    journal: 'Followed the plan.',
+    long_short: 'long',
+    playbook: false,
+    pnl: 280,
+    risk: 200,
+    stop: 2340,
+    symbol: 'GC',
+    target: 2400,
+    time_frame: '30m',
+    user_id: MOCK_USER_ID,
+  },
+  {
+    id: 9,
+    account: 1,
+    amount: 1,
+    created_at: previousMonthOn(5),
+    entry: 5610,
+    executed: true,
+    exit: 5578,
+    fees: 2.25,
+    journal: null,
+    long_short: 'short',
+    playbook: false,
+    pnl: 320,
+    risk: 250,
+    stop: 5635,
+    symbol: 'ES',
+    target: 5560,
+    time_frame: '15m',
+    user_id: MOCK_USER_ID,
+  },
+];
+
+export const mockTradesSpot: TradesSpotRow[] = [
+  {
+    id: 1,
+    amount: 0.25,
+    created_at: daysAgo(3),
+    description: 'Swing long on breakout above range.',
+    entry: 58200,
+    executed: true,
+    exit: 61400,
+    pnl: 800,
+    symbol: 'BTC',
+    url: null,
+    user_id: MOCK_USER_ID,
+  },
+  {
+    id: 2,
+    amount: 2,
+    created_at: daysAgo(1),
+    description: 'Still holding, targeting 3400.',
+    entry: 3120,
+    executed: true,
+    exit: null,
+    pnl: null,
+    symbol: 'ETH',
+    url: null,
+    user_id: MOCK_USER_ID,
+  },
+  {
+    id: 3,
+    amount: 15,
+    created_at: daysAgo(6),
+    description: 'Cut early on broken support.',
+    entry: 142.5,
+    executed: true,
+    exit: 129.8,
+    pnl: -190,
+    symbol: 'SOL',
+    url: null,
+    user_id: MOCK_USER_ID,
+  },
+  {
+    id: 4,
+    amount: 0.1,
+    created_at: previousMonthOn(18),
+    description: null,
+    entry: 60500,
+    executed: true,
+    exit: 63100,
+    pnl: 260,
+    symbol: 'BTC',
+    url: null,
+    user_id: MOCK_USER_ID,
+  },
+  {
+    id: 5,
+    amount: 1.5,
+    created_at: previousMonthOn(8),
+    description: 'Faded resistance too soon.',
+    entry: 3050,
+    executed: true,
+    exit: 2980,
+    pnl: -105,
+    symbol: 'ETH',
+    url: null,
+    user_id: MOCK_USER_ID,
+  },
+];
+
+export const mockMonthlyPlans: MonthlyPlanRow[] = [
+  {
+    id: 'mock-plan-current-month',
+    content:
+      '# Monthly Plan\n\n- Focus on ES and NQ during the first hour of the session.\n- Max 2 losing trades per day before stopping.\n- Review playbook setups every Friday.',
+    created_at: daysAgo(6),
+    month_year: currentMonthKey(),
+    updated_at: daysAgo(1),
+    user_id: MOCK_USER_ID,
+  },
+];
+
+let tradeIdCounter = 1000;
+export function nextMockTradeId(): number {
+  return tradeIdCounter++;
+}
+
+let spotIdCounter = 1000;
+export function nextMockSpotId(): number {
+  return spotIdCounter++;
+}
+
+export function mockFindIndexById<T extends { id: number | string }>(
+  rows: T[],
+  id: T['id'],
+): number {
+  return rows.findIndex((row) => row.id === id);
+}
+
+export function mockUpdateRow<T extends { id: number | string }>(
+  rows: T[],
+  id: T['id'],
+  patch: Partial<T>,
+): T {
+  const index = mockFindIndexById(rows, id);
+  if (index === -1) throw new Error(`Mock row with id ${id} not found`);
+  rows[index] = { ...rows[index], ...patch };
+  return rows[index];
+}
+
+export function mockDeleteRow<T extends { id: number | string }>(
+  rows: T[],
+  id: T['id'],
+): void {
+  const index = mockFindIndexById(rows, id);
+  if (index !== -1) rows.splice(index, 1);
+}

--- a/src/lib/mock/mockMode.ts
+++ b/src/lib/mock/mockMode.ts
@@ -1,0 +1,1 @@
+export const isMockMode = import.meta.env.MODE === 'mock';

--- a/src/routes/Layout.tsx
+++ b/src/routes/Layout.tsx
@@ -1,4 +1,5 @@
 import { supabase } from '@lib/database/SupabaseClient';
+import { isMockMode } from '@lib/mock/mockMode';
 import { Book, LogOut } from 'react-feather';
 import { Link } from '@tanstack/react-router';
 import { useSessionContext } from '../lib/context/SessionContext';
@@ -47,7 +48,11 @@ export default function Layout({ children }: { children?: React.ReactNode }) {
           {session?.user.user_metadata['display_name'] || session?.user.email}
         </span>
         <button
-          onClick={() => supabase.auth.signOut()}
+          onClick={() =>
+            isMockMode
+              ? console.info('[mock mode] sign-out is a no-op')
+              : supabase.auth.signOut()
+          }
           title="logout"
           aria-label="logout"
         >


### PR DESCRIPTION
## Summary
Adds a mock mode that allows the app to run entirely without a Supabase backend, enabling offline development and testing with realistic demo data.

## Key Changes
- **New mock data module** (`src/lib/mock/mockData.ts`): Comprehensive mock datasets for trades, spot trades, monthly plans, and a mock session with helper functions for CRUD operations
- **Mock mode detection** (`src/lib/mock/mockMode.ts`): Simple flag that checks if the app is running in `mock` Vite mode
- **API layer integration**: Updated all database API functions (`TradesApi.ts`, `SpotApi.ts`, `MonthlyPlanApi.ts`) to check `isMockMode` and use in-memory mock data instead of Supabase calls
- **Session context**: Mock session is automatically loaded when in mock mode, bypassing Supabase auth
- **Supabase client**: Safely nullified in mock mode to prevent initialization errors
- **Layout component**: Sign-out button gracefully handles mock mode
- **Dev script**: Added `npm run dev:mock` to start the dev server in mock mode

## Implementation Details
- Mock data includes 9 futures trades, 5 spot trades, and 1 monthly plan with realistic trading scenarios (open/closed positions, various symbols, profit/loss outcomes)
- Helper functions (`mockUpdateRow`, `mockDeleteRow`, `mockFindIndexById`) provide consistent CRUD semantics matching the Supabase API
- ID generation uses incrementing counters for trades/spots and UUID for monthly plans
- All mock operations are synchronous but wrapped in async functions to maintain API compatibility
- Mock trades are sorted by creation date (newest first) to match production behavior

https://claude.ai/code/session_01AJzzvznJDXMaXewTLSQhvQ