### PR TITLE
Support separate dev and production Supabase projects

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Production Supabase project (traders-tale) — used for `npm run build` / `npm run deploy`
+VITE_SUPABASE_URL=
+VITE_SUPABASE_KEY=
+
+# Dev Supabase project (traders-tale-dev) — used for `npm run dev`
+VITE_SUPABASE_DEV_URL=
+VITE_SUPABASE_DEV_KEY=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,12 @@ SessionProvider       → Supabase auth session, redirects to /auth if unauthent
 
 ### Database layer (`src/lib/database/`)
 
-All API functions use the singleton `supabase` client from `SupabaseClient.ts`, which reads `VITE_SUPABASE_URL` and `VITE_SUPABASE_KEY` from `.env.local`. They throw the Supabase error directly on failure.
+All API functions use the singleton `supabase` client from `SupabaseClient.ts`. It picks its Supabase project based on `import.meta.env.DEV` (Vite's dev-server flag):
+
+- **`npm run dev`** → `VITE_SUPABASE_DEV_URL` / `VITE_SUPABASE_DEV_KEY` (the `traders-tale-dev` project)
+- **`npm run build`/`npm run deploy`** → `VITE_SUPABASE_URL` / `VITE_SUPABASE_KEY` (the `traders-tale` production project)
+
+All four vars are read from `.env.local` (see `.env.example` for the expected names). API functions throw the Supabase error directly on failure.
 
 - `TradesApi.ts` — futures trades CRUD; types re-exported from `database.types.ts`
 - `SpotApi.ts` — spot trades CRUD

--- a/src/lib/database/SupabaseClient.ts
+++ b/src/lib/database/SupabaseClient.ts
@@ -1,7 +1,11 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from '@lib/types/database.types';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseKey = import.meta.env.VITE_SUPABASE_KEY;
+const supabaseUrl = import.meta.env.DEV
+  ? import.meta.env.VITE_SUPABASE_DEV_URL
+  : import.meta.env.VITE_SUPABASE_URL;
+const supabaseKey = import.meta.env.DEV
+  ? import.meta.env.VITE_SUPABASE_DEV_KEY
+  : import.meta.env.VITE_SUPABASE_KEY;
 
 export const supabase = createClient<Database>(supabaseUrl, supabaseKey);


### PR DESCRIPTION
## Summary

Enable the app to use different Supabase projects for development and production environments. The Supabase client now conditionally selects credentials based on whether the app is running in dev mode (`npm run dev`) or production mode (`npm run build`/`npm run deploy`).

## Changes

- **SupabaseClient.ts**: Updated to check `import.meta.env.DEV` and select the appropriate Supabase URL and API key:
  - Dev mode → `VITE_SUPABASE_DEV_URL` / `VITE_SUPABASE_DEV_KEY` (traders-tale-dev project)
  - Production mode → `VITE_SUPABASE_URL` / `VITE_SUPABASE_KEY` (traders-tale production project)

- **.env.example**: Added template with all four required environment variables, clearly labeled by environment and use case

- **CLAUDE.md**: Updated database layer documentation to reflect the new dual-project setup and clarify that all four variables must be configured in `.env.local`

## Implementation Details

The selection uses Vite's built-in `import.meta.env.DEV` flag, which is automatically set based on whether the dev server or production build is running. This ensures the correct project is used without requiring manual configuration switching.

https://claude.ai/code/session_015Jm1gE7XbB2nPFqL5GX2k7